### PR TITLE
Fix/profile nav

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -19,7 +19,9 @@ android {
 
     kotlinOptions {
         jvmTarget = JavaVersion.VERSION_1_8
-    }    defaultConfig {
+    }
+
+    defaultConfig {
         // TODO: Specify your own unique Application ID (https://developer.android.com/studio/build/application-id.html).
         applicationId = "org.medmap.homecare"
         // You can update the following values to match your application needs.

--- a/android/app/google-services.json
+++ b/android/app/google-services.json
@@ -1,0 +1,48 @@
+// TODO: Replace with actual firebase json
+{
+  "project_info": {
+    "project_number": "123456789012",
+    "project_id": "your-project-id",
+    "storage_bucket": "your-project-id.appspot.com"
+  },
+  "client": [
+    {
+      "client_info": {
+        "mobilesdk_app_id": "1:123456789012:android:abcdef1234567890",
+        "android_client_info": {
+          "package_name": "org.medmap.homecare"
+        }
+      },
+      "oauth_client": [
+        {
+          "client_id": "123456789012-abcdefghijklmnopqrstuvwxyz123456.apps.googleusercontent.com",
+          "client_type": 1,
+          "android_info": {
+            "package_name": "org.medmap.homecare",
+            "certificate_hash": "your_sha1_fingerprint_here"
+          }
+        },
+        {
+          "client_id": "123456789012-abcdefghijklmnopqrstuvwxyz123456.apps.googleusercontent.com",
+          "client_type": 3
+        }
+      ],
+      "api_key": [
+        {
+          "current_key": "your_api_key_here"
+        }
+      ],
+      "services": {
+        "appinvite_service": {
+          "other_platform_oauth_client": [
+            {
+              "client_id": "123456789012-abcdefghijklmnopqrstuvwxyz123456.apps.googleusercontent.com",
+              "client_type": 3
+            }
+          ]
+        }
+      }
+    }
+  ],
+  "configuration_version": "1"
+}

--- a/android/gradle/wrapper/gradle-wrapper.properties
+++ b/android/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip

--- a/android/settings.gradle
+++ b/android/settings.gradle
@@ -18,8 +18,8 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.1.0" apply false
-    id "org.jetbrains.kotlin.android" version "1.8.22" apply false
+    id "com.android.application" version "8.12.0" apply false
+    id "org.jetbrains.kotlin.android" version "2.1.0" apply false
 }
 
 include ":app"

--- a/lib/cubit/appointment/appointment_detail.dart
+++ b/lib/cubit/appointment/appointment_detail.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:intl/intl.dart';
 import 'package:m2health/const.dart';
 import 'package:m2health/main.dart';
+import 'package:m2health/route/app_routes.dart';
 import 'package:m2health/utils.dart';
 import 'package:dio/dio.dart';
 import 'package:m2health/views/payment.dart';
@@ -543,13 +545,7 @@ class _DetailAppointmentPageState extends State<DetailAppointmentPage> {
                                 ),
                                 ElevatedButton(
                                   onPressed: () {
-                                    Navigator.pop(context);
-                                    Navigator.pushReplacement(
-                                      context,
-                                      MaterialPageRoute(
-                                        builder: (context) => HomePage(),
-                                      ),
-                                    );
+                                    context.go(AppRoutes.home);
                                   },
                                   child: const Text('Yes, Cancel'),
                                   style: ElevatedButton.styleFrom(

--- a/lib/cubit/nursing/pages/detail_appointment_page.dart
+++ b/lib/cubit/nursing/pages/detail_appointment_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:go_router/go_router.dart';
 import 'package:m2health/const.dart';
 import 'package:m2health/main.dart';
+import 'package:m2health/route/app_routes.dart';
 import 'package:m2health/utils.dart';
 import 'package:dio/dio.dart';
 import 'package:m2health/cubit/nursingclean/presentation/pages/payment_page.dart';
@@ -270,15 +272,8 @@ class _DetailAppointmentPageState extends State<DetailAppointmentPage> {
   }
 
   void _navigateToAppointmentPage() {
-    Navigator.pop(context);
-    Navigator.pushReplacement(
-      context,
-      MaterialPageRoute(
-        builder: (context) => HomePage(),
-      ),
-    ).then((_) {
-      MyApp.showBottomAppBar(context);
-    });
+    context.go(AppRoutes.home);
+    MyApp.showBottomAppBar(context);
   }
 
   @override

--- a/lib/cubit/nursing/pages/nursing_services_page.dart
+++ b/lib/cubit/nursing/pages/nursing_services_page.dart
@@ -33,27 +33,27 @@ class NursingCard extends StatelessWidget {
               children: [
                 Text(
                   '${pharma['title']}',
-                  style: TextStyle(
+                  style: const TextStyle(
                     fontSize: 22,
                     fontWeight: FontWeight.bold,
                   ),
                 ),
-                SizedBox(height: 10),
+                const SizedBox(height: 10),
                 Text(
                   '${pharma['description']}',
-                  style: TextStyle(
+                  style: const TextStyle(
                     fontSize: 12,
                     fontWeight: FontWeight.w400, // Light font weight
                   ),
                 ),
-                SizedBox(height: 10),
+                const SizedBox(height: 10),
                 TextButton(
                   onPressed: onTap,
                   child: Row(
                     mainAxisSize: MainAxisSize.min,
                     children: [
-                      SizedBox(width: 5),
-                      Text(
+                      const SizedBox(width: 5),
+                      const Text(
                         'Book Now',
                         style: TextStyle(
                           fontWeight: FontWeight.bold,
@@ -61,7 +61,7 @@ class NursingCard extends StatelessWidget {
                           color: Color(0xFF35C5CF),
                         ),
                       ),
-                      SizedBox(width: 5),
+                      const SizedBox(width: 5),
                       Image.asset(
                         'assets/icons/ic_play.png',
                         width: 20,
@@ -120,10 +120,10 @@ class _NursingState extends State<NursingService> {
     return Scaffold(
       appBar: AppBar(
         title: Text(AppLocalizations.of(context)!.translate('nursing'),
-            style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18)),
+            style: const TextStyle(fontWeight: FontWeight.bold, fontSize: 18)),
       ),
       body: Container(
-        margin: EdgeInsets.fromLTRB(0, 0, 0, 60.0),
+        margin: const EdgeInsets.fromLTRB(0, 0, 0, 60.0),
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
@@ -176,7 +176,7 @@ class _NursingState extends State<NursingService> {
                             : 1.0),
                   );
                 },
-                separatorBuilder: (context, index) => Divider(height: 1),
+                separatorBuilder: (context, index) => const Divider(height: 1),
               ),
             ),
           ],

--- a/lib/cubit/nursing/pages/payment.dart
+++ b/lib/cubit/nursing/pages/payment.dart
@@ -3,6 +3,7 @@ import 'package:m2health/const.dart';
 import 'package:m2health/main.dart';
 import 'package:m2health/cubit/appointment/appointment_page.dart';
 import 'package:go_router/go_router.dart';
+import 'package:m2health/route/app_routes.dart';
 import 'package:m2health/widgets/bottombar.dart';
 // import 'package:navbar_router/navbar_router.dart';
 
@@ -326,13 +327,7 @@ class PaymentSuccessDialog extends StatelessWidget {
             height: 50,
             child: ElevatedButton(
               onPressed: () {
-                Navigator.pop(context);
-                Navigator.pushReplacement(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => HomePage(),
-                  ),
-                );
+                context.go(AppRoutes.home);
               },
               style: ElevatedButton.styleFrom(
                 backgroundColor: Const.tosca,
@@ -596,16 +591,9 @@ class FeedbackDetails extends StatelessWidget {
                 width: 300,
                 child: ElevatedButton(
                   onPressed: () {
-                    Navigator.pop(context);
-                    Navigator.pushReplacement(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => HomePage(),
-                      ),
-                    ).then((_) {
-                      // Show the bottom navigation bar after navigation completes
-                      MyApp.showBottomAppBar(context);
-                    });
+                    context.go(AppRoutes.home);
+                    // Show the bottom navigation bar after navigation completes
+                    MyApp.showBottomAppBar(context);
                   },
                   child: const Text(
                     'View Detail',

--- a/lib/cubit/nursing/pages/payment_page.dart
+++ b/lib/cubit/nursing/pages/payment_page.dart
@@ -3,6 +3,7 @@ import 'package:m2health/const.dart';
 import 'package:m2health/main.dart';
 import 'package:m2health/cubit/appointment/appointment_page.dart';
 import 'package:go_router/go_router.dart';
+import 'package:m2health/route/app_routes.dart';
 import 'package:m2health/widgets/bottombar.dart';
 
 class PaymentPage extends StatefulWidget {
@@ -311,13 +312,7 @@ class PaymentSuccessDialog extends StatelessWidget {
             height: 50,
             child: ElevatedButton(
               onPressed: () {
-                Navigator.pop(context);
-                Navigator.pushReplacement(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => HomePage(),
-                  ),
-                );
+                context.go(AppRoutes.home);
               },
               style: ElevatedButton.styleFrom(
                 backgroundColor: Const.tosca,

--- a/lib/cubit/nursingclean/presentation/pages/detail_appointment_page.dart
+++ b/lib/cubit/nursingclean/presentation/pages/detail_appointment_page.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:go_router/go_router.dart';
 import 'package:m2health/const.dart';
 import 'package:m2health/main.dart';
+import 'package:m2health/route/app_routes.dart';
 import 'package:m2health/utils.dart';
 import 'package:dio/dio.dart';
 import 'package:m2health/cubit/nursingclean/presentation/pages/payment_page.dart';
@@ -270,15 +272,8 @@ class _DetailAppointmentPageState extends State<DetailAppointmentPage> {
   }
 
   void _navigateToAppointmentPage() {
-    Navigator.pop(context);
-    Navigator.pushReplacement(
-      context,
-      MaterialPageRoute(
-        builder: (context) => HomePage(),
-      ),
-    ).then((_) {
-      MyApp.showBottomAppBar(context);
-    });
+    context.go(AppRoutes.appointment);
+    MyApp.showBottomAppBar(context);
   }
 
   @override

--- a/lib/cubit/nursingclean/presentation/pages/payment.dart
+++ b/lib/cubit/nursingclean/presentation/pages/payment.dart
@@ -3,6 +3,7 @@ import 'package:m2health/const.dart';
 import 'package:m2health/main.dart';
 import 'package:m2health/cubit/appointment/appointment_page.dart';
 import 'package:go_router/go_router.dart';
+import 'package:m2health/route/app_routes.dart';
 import 'package:m2health/widgets/bottombar.dart';
 // import 'package:navbar_router/navbar_router.dart';
 
@@ -326,13 +327,7 @@ class PaymentSuccessDialog extends StatelessWidget {
             height: 50,
             child: ElevatedButton(
               onPressed: () {
-                Navigator.pop(context);
-                Navigator.pushReplacement(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => HomePage(),
-                  ),
-                );
+                context.go(AppRoutes.home);
               },
               style: ElevatedButton.styleFrom(
                 backgroundColor: Const.tosca,
@@ -596,16 +591,8 @@ class FeedbackDetails extends StatelessWidget {
                 width: 300,
                 child: ElevatedButton(
                   onPressed: () {
-                    Navigator.pop(context);
-                    Navigator.pushReplacement(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => HomePage(),
-                      ),
-                    ).then((_) {
-                      // Show the bottom navigation bar after navigation completes
-                      MyApp.showBottomAppBar(context);
-                    });
+                    context.go(AppRoutes.home);
+                    MyApp.showBottomAppBar(context);
                   },
                   child: const Text(
                     'View Detail',

--- a/lib/cubit/nursingclean/presentation/pages/payment_page.dart
+++ b/lib/cubit/nursingclean/presentation/pages/payment_page.dart
@@ -3,6 +3,7 @@ import 'package:m2health/const.dart';
 import 'package:m2health/main.dart';
 import 'package:m2health/cubit/appointment/appointment_page.dart';
 import 'package:go_router/go_router.dart';
+import 'package:m2health/route/app_routes.dart';
 import 'package:m2health/widgets/bottombar.dart';
 
 class PaymentPage extends StatefulWidget {
@@ -311,13 +312,7 @@ class PaymentSuccessDialog extends StatelessWidget {
             height: 50,
             child: ElevatedButton(
               onPressed: () {
-                Navigator.pop(context);
-                Navigator.pushReplacement(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => HomePage(),
-                  ),
-                );
+                context.go(AppRoutes.home);
               },
               style: ElevatedButton.styleFrom(
                 backgroundColor: Const.tosca,

--- a/lib/cubit/profiles/profile_details/edit_profile.dart
+++ b/lib/cubit/profiles/profile_details/edit_profile.dart
@@ -6,6 +6,16 @@ import 'package:m2health/cubit/profiles/profile_state.dart';
 import 'package:image_picker/image_picker.dart';
 import 'dart:io';
 
+class EditProfilePageArgs {
+  final ProfileCubit profileCubit;
+  final Profile profile;
+
+  EditProfilePageArgs({
+    required this.profileCubit,
+    required this.profile,
+  });
+}
+
 class EditProfilePage extends StatefulWidget {
   final Profile profile;
 

--- a/lib/cubit/profiles/profile_page.dart
+++ b/lib/cubit/profiles/profile_page.dart
@@ -93,17 +93,16 @@ class ProfilePage extends StatelessWidget {
                           children: [
                             GestureDetector(
                               onTap: () async {
-                                await Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (_) => BlocProvider.value(
-                                      value: context.read<ProfileCubit>(),
-                                      child: EditProfilePage(
-                                          profile: state.profile),
-                                    ),
+                                await context.push(
+                                  AppRoutes.editProfile,
+                                  extra: EditProfilePageArgs(
+                                    profileCubit: context.read<ProfileCubit>(),
+                                    profile: state.profile,
                                   ),
                                 );
-                                context.read<ProfileCubit>().fetchProfile();
+                                if (context.mounted) {
+                                  context.read<ProfileCubit>().fetchProfile();
+                                }
                               },
                               child: ClipRRect(
                                 borderRadius: BorderRadius.circular(10.0),
@@ -199,12 +198,7 @@ class ProfilePage extends StatelessWidget {
                                     Icons.arrow_forward_ios,
                                   ),
                                   onTap: () {
-                                    Navigator.push(
-                                      context,
-                                      MaterialPageRoute(
-                                          builder: (context) =>
-                                              MedicalRecordsPage()),
-                                    );
+                                    context.push(AppRoutes.medicalRecord);
                                   },
                                 ),
                                 // ListTile(
@@ -226,13 +220,7 @@ class ProfilePage extends StatelessWidget {
                                   title: const Text('Pharmagenomics Profile'),
                                   trailing: const Icon(Icons.arrow_forward_ios),
                                   onTap: () {
-                                    Navigator.push(
-                                      context,
-                                      MaterialPageRoute(
-                                        builder: (context) =>
-                                            PharmagenomicsProfilePage(),
-                                      ),
-                                    );
+                                    context.push(AppRoutes.pharmagenomics);
                                   },
                                 ),
                                 ListTile(
@@ -300,12 +288,7 @@ class ProfilePage extends StatelessWidget {
                                   title: const Text('All My Appointments'),
                                   trailing: const Icon(Icons.arrow_forward_ios),
                                   onTap: () {
-                                    Navigator.push(
-                                      context,
-                                      MaterialPageRoute(
-                                        builder: (context) => AppointmentPage(),
-                                      ),
-                                    );
+                                    context.go(AppRoutes.appointment);
                                   },
                                 ),
                               ],
@@ -324,17 +307,16 @@ class ProfilePage extends StatelessWidget {
                             IconButton(
                               icon: const Icon(Icons.edit),
                               onPressed: () async {
-                                await Navigator.push(
-                                  context,
-                                  MaterialPageRoute(
-                                    builder: (_) => BlocProvider.value(
-                                      value: context.read<ProfileCubit>(),
-                                      child: EditProfilePage(
-                                          profile: state.profile),
-                                    ),
+                                await context.push(
+                                  AppRoutes.editProfile,
+                                  extra: EditProfilePageArgs(
+                                    profileCubit: context.read<ProfileCubit>(),
+                                    profile: state.profile,
                                   ),
                                 );
-                                context.read<ProfileCubit>().fetchProfile();
+                                if (context.mounted) {
+                                  context.read<ProfileCubit>().fetchProfile();
+                                }
                               },
                             ),
                           ],
@@ -376,6 +358,7 @@ class ProfilePage extends StatelessWidget {
                             ),
                           ),
                         ),
+                        const SizedBox(height: 80)
                       ],
                     ),
                   ),

--- a/lib/cubit/signin/sign_in_page.dart
+++ b/lib/cubit/signin/sign_in_page.dart
@@ -56,7 +56,7 @@ class _SignInPageState extends State<SignInPage> {
           child: BlocConsumer<SignInCubit, SignInState>(
             listener: (context, state) {
               if (state is SignInSuccess) {
-                context.go('/dasboard');
+                context.go(AppRoutes.dashboard);
               } else if (state is SignInError) {
                 showDialog(
                   context: context,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -19,6 +19,7 @@ import 'package:m2health/cubit/appointment/appointment_cubit.dart';
 import 'package:m2health/cubit/appointment/provider_appointment_cubit.dart';
 import 'package:dio/dio.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 // import 'package:navbar_router/navbar_router.dart';
 
 import 'const.dart';
@@ -341,285 +342,93 @@ class AppSetting extends ChangeNotifier {
   }
 }
 
-class HomePage extends StatefulWidget {
-  const HomePage({Key? key}) : super(key: key);
+class AppShell extends StatelessWidget {
+  final StatefulNavigationShell navigationShell;
 
-  @override
-  State<HomePage> createState() => _HomePageState();
-}
-
-class _HomePageState extends State<HomePage>
-    with WidgetsBindingObserver, TickerProviderStateMixin {
-  bool _resumedFromBackground = false;
-  bool _showBottomBar = true;
-
-  late TabController tabController;
-
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addObserver(this);
-    tabController = TabController(length: 5, vsync: this);
-    tabController.addListener(_handleTabSelection);
-  }
-
-  @override
-  void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-    tabController.removeListener(_handleTabSelection);
-    tabController.dispose();
-    super.dispose();
-  }
-
-  void _handleTabSelection() {
-    setState(() {
-      // Hide BottomBar on the third tab (index 2)
-      _showBottomBar = tabController.index != 2;
-    });
-  }
-
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.resumed) {
-      _resumedFromBackground = true;
-      print("onResume");
-    }
-  }
+  const AppShell({
+    super.key,
+    required this.navigationShell,
+  });
 
   @override
   Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
-        if (_resumedFromBackground) {
-          _resumedFromBackground = false;
-          return false; // Prevent default back button behavior
-        } else {
-          return true; // Allow default back button behavior
-        }
-      },
-      child: Padding(
-        padding: const EdgeInsets.only(
-            top: .0), // Adjust the bottom padding as needed
-        child: Stack(
-          children: [
-            BottomBar(
-              fit: StackFit.expand,
-              icon: (width, height) => Center(
-                child: IconButton(
-                  padding: EdgeInsets.zero,
-                  onPressed: null,
-                  icon: Icon(
-                    Icons.arrow_upward_rounded,
-                    color: Colors.grey, // Replace with your unselected color
-                    size: width,
-                  ),
-                ),
-              ),
-              borderRadius: BorderRadius.circular(
-                  20), // Adjust the border radius as needed
-              duration: const Duration(seconds: 1),
-              curve: Curves.decelerate,
-              showIcon: true,
-              width: MediaQuery.of(context).size.width * 0.8,
-              barColor: Colors.white, // Replace with your bar color
-              start: 2,
-              end: 0,
-              offset: 10,
-              barAlignment: Alignment.bottomCenter,
-              iconHeight: 35,
-              iconWidth: 35,
-              reverse: false,
-              barDecoration: BoxDecoration(
-                color: Colors.blue, // Replace with your current page color
-                borderRadius: BorderRadius.circular(
-                    20), // Adjust the border radius as needed
-              ),
-              iconDecoration: BoxDecoration(
-                color: Colors.blue, // Replace with your current page color
-                borderRadius: BorderRadius.circular(
-                    20), // Adjust the border radius as needed
-              ),
-              hideOnScroll: true,
-              scrollOpposite: false,
-              onBottomBarHidden: () {},
-              onBottomBarShown: () {},
-              body: (context, controller) => TabBarView(
-                controller: tabController,
-                dragStartBehavior: DragStartBehavior.down,
-                physics: const BouncingScrollPhysics(),
-                children: [
-                  Dashboard(),
-                  AppointmentPage(),
-                  MedicalStorePage(),
-                  FavouritesPage(),
-                  ProfilePage(), // Add your pages here
-                ],
-              ),
-              child: TabBar(
-                controller: tabController,
-                tabs: const [
-                  Tab(icon: Icon(Icons.home_outlined)),
-                  Tab(icon: Icon(Icons.calendar_month_outlined)),
-                  Tab(icon: Icon(Icons.add_shopping_cart_outlined)),
-                  Tab(icon: Icon(Icons.favorite_border_outlined)),
-                  Tab(icon: Icon(Icons.person_outline)),
-                ],
-                indicatorColor: const Color(0xFF40E0D0), // Warna tosca
-              ),
-            ),
-            if (!_showBottomBar)
-              Positioned(
-                bottom: 0,
-                left: 0,
-                right: 0,
-                child: Container(
-                  height: 0, // Hide BottomBar by setting height to 0
-                ),
-              ),
-          ],
-        ),
+    return Scaffold(
+      body: Stack(
+        children: [
+          Padding(
+            padding: const EdgeInsets.only(bottom: 32),
+            child: navigationShell,
+          ),
+          Align(
+            alignment: Alignment.bottomCenter,
+            child: _buildFloatingNavBar(context),
+          ),
+        ],
       ),
     );
   }
-}
 
-class BottomAppBar extends StatefulWidget {
-  const BottomAppBar({Key? key}) : super(key: key);
+  Widget _buildFloatingNavBar(BuildContext context) {
+    final currentIndex = navigationShell.currentIndex;
 
-  @override
-  _CustomBottomAppBarState createState() => _CustomBottomAppBarState();
-}
-
-class _CustomBottomAppBarState extends State<BottomAppBar>
-    with WidgetsBindingObserver, TickerProviderStateMixin {
-  bool _resumedFromBackground = false;
-  bool _showBottomBar = true;
-
-  late TabController tabController;
-
-  @override
-  void initState() {
-    super.initState();
-    WidgetsBinding.instance.addObserver(this);
-    tabController = TabController(length: 5, vsync: this);
-    tabController.addListener(_handleTabSelection);
-  }
-
-  @override
-  void dispose() {
-    WidgetsBinding.instance.removeObserver(this);
-    tabController.removeListener(_handleTabSelection);
-    tabController.dispose();
-    super.dispose();
-  }
-
-  void _handleTabSelection() {
-    setState(() {
-      // Hide BottomBar on the third tab (index 2)
-      _showBottomBar = tabController.index != 2;
-    });
-  }
-
-  @override
-  void didChangeAppLifecycleState(AppLifecycleState state) {
-    if (state == AppLifecycleState.resumed) {
-      _resumedFromBackground = true;
-      print("onResume");
-    }
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return WillPopScope(
-      onWillPop: () async {
-        if (_resumedFromBackground) {
-          _resumedFromBackground = false;
-          return false; // Prevent default back button behavior
-        } else {
-          return true; // Allow default back button behavior
-        }
-      },
-      child: Padding(
-        padding: const EdgeInsets.only(
-            top: .0), // Adjust the bottom padding as needed
-        child: Stack(
-          children: [
-            BottomBar(
-              fit: StackFit.expand,
-              icon: (width, height) => Center(
-                child: IconButton(
-                  padding: EdgeInsets.zero,
-                  onPressed: null,
-                  icon: Icon(
-                    Icons.arrow_upward_rounded,
-                    color: Colors.grey, // Replace with your unselected color
-                    size: width,
-                  ),
-                ),
-              ),
-              borderRadius: BorderRadius.circular(
-                  20), // Adjust the border radius as needed
-              duration: const Duration(seconds: 1),
-              curve: Curves.decelerate,
-              showIcon: true,
-              width: MediaQuery.of(context).size.width * 0.8,
-              barColor: Colors.white, // Replace with your bar color
-              start: 2,
-              end: 0,
-              offset: 10,
-              barAlignment: Alignment.bottomCenter,
-              iconHeight: 35,
-              iconWidth: 35,
-              reverse: false,
-              barDecoration: BoxDecoration(
-                color: Colors.blue, // Replace with your current page color
-                borderRadius: BorderRadius.circular(
-                    20), // Adjust the border radius as needed
-              ),
-              iconDecoration: BoxDecoration(
-                color: Colors.blue, // Replace with your current page color
-                borderRadius: BorderRadius.circular(
-                    20), // Adjust the border radius as needed
-              ),
-              hideOnScroll: true,
-              scrollOpposite: false,
-              onBottomBarHidden: () {},
-              onBottomBarShown: () {},
-              body: (context, controller) => TabBarView(
-                controller: tabController,
-                dragStartBehavior: DragStartBehavior.down,
-                physics: const BouncingScrollPhysics(),
-                children: [
-                  Dashboard(),
-                  AppointmentPage(),
-                  MedicalStorePage(),
-                  FavouritesPage(),
-                  ProfilePage(), // Add your pages here
-                ],
-              ),
-              child: TabBar(
-                controller: tabController,
-                tabs: const [
-                  Tab(icon: Icon(Icons.home_outlined)),
-                  Tab(icon: Icon(Icons.calendar_month_outlined)),
-                  Tab(icon: Icon(Icons.add_shopping_cart_outlined)),
-                  Tab(icon: Icon(Icons.favorite_border_outlined)),
-                  Tab(icon: Icon(Icons.person_outline)),
-                ],
-                indicatorColor: const Color(0xFF40E0D0), // Warna tosca
-              ),
-            ),
-            if (!_showBottomBar)
-              Positioned(
-                bottom: 0,
-                left: 0,
-                right: 0,
-                child: Container(
-                  height: 0, // Hide BottomBar by setting height to 0
-                ),
-              ),
-          ],
-        ),
+    return Container(
+      height: 80,
+      margin: const EdgeInsets.only(bottom: 20, left: 24, right: 24),
+      decoration: BoxDecoration(
+        color: Colors.white,
+        borderRadius: BorderRadius.circular(20),
+        boxShadow: [
+          BoxShadow(
+            color: Colors.black.withValues(alpha: 0.05),
+            blurRadius: 8,
+            offset: const Offset(0, 2),
+          ),
+        ],
+      ),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.spaceAround,
+        children: [
+          IconButton(
+            onPressed: () => navigationShell.goBranch(0),
+            icon: const Icon(Icons.home_outlined),
+            iconSize: 28,
+            color: currentIndex == 0
+                ? const Color(0xFF40E0D0)
+                : const Color(0xFF8A96BC),
+          ),
+          IconButton(
+            onPressed: () => navigationShell.goBranch(1),
+            icon: const Icon(Icons.calendar_month_outlined),
+            iconSize: 28,
+            color: currentIndex == 1
+                ? const Color(0xFF40E0D0)
+                : const Color(0xFF8A96BC),
+          ),
+          IconButton(
+            onPressed: () => navigationShell.goBranch(2),
+            icon: const Icon(Icons.add_shopping_cart_outlined),
+            iconSize: 28,
+            color: currentIndex == 2
+                ? const Color(0xFF40E0D0)
+                : const Color(0xFF8A96BC),
+          ),
+          IconButton(
+            onPressed: () => navigationShell.goBranch(3),
+            icon: const Icon(Icons.favorite_border_outlined),
+            iconSize: 28,
+            color: currentIndex == 3
+                ? const Color(0xFF40E0D0)
+                : const Color(0xFF8A96BC),
+          ),
+          IconButton(
+            onPressed: () => navigationShell.goBranch(4),
+            icon: const Icon(Icons.person_outline),
+            iconSize: 28,
+            color: currentIndex == 4
+                ? const Color(0xFF40E0D0)
+                : const Color(0xFF8A96BC),
+          ),
+        ],
       ),
     );
   }

--- a/lib/route/app_router.dart
+++ b/lib/route/app_router.dart
@@ -1,24 +1,78 @@
 import 'package:flutter/material.dart';
+import 'package:m2health/cubit/appointment/appointment_module.dart';
+import 'package:m2health/cubit/nursing/pages/nursing_services_page.dart';
+import 'package:m2health/cubit/nursingclean/presentation/pages/pharmacist_services.dart';
 import 'package:m2health/views/appointment/unified_appointment_page.dart';
 import 'package:go_router/go_router.dart';
 import 'package:m2health/cubit/locations/location_page.dart';
 import 'package:m2health/cubit/profiles/profile_page.dart';
 import 'package:m2health/cubit/signup/sign_up_page.dart';
 import 'package:m2health/cubit/signin/sign_in_page.dart';
-// import 'package:m2health/cubit/submenu/submenu_page.dart';
 import 'package:m2health/cubit/pharmacist_profile/pharmacist_profile_page.dart';
 import 'package:m2health/cubit/personal/personal_page.dart';
-// import 'package:m2health/cubit/nursing/nursing_page.dart';
 import 'package:m2health/main.dart';
 import 'package:m2health/views/dashboard.dart';
+import 'package:m2health/views/diabetic_care.dart';
+import 'package:m2health/views/favourites.dart';
+import 'package:m2health/views/medical_store.dart';
+import 'package:path/path.dart';
 import 'app_routes.dart';
 
+final _rootNavigatorKey = GlobalKey<NavigatorState>();
+final _shellNavigatorKey = GlobalKey<NavigatorState>();
+
 final GoRouter router = GoRouter(
+  initialLocation: AppRoutes.dashboard,
+  navigatorKey: _rootNavigatorKey,
   routes: [
-    GoRoute(
-      path: '/',
-      name: 'home',
-      builder: (context, state) => HomePage(),
+    // For routes with NavigationBar
+    StatefulShellRoute.indexedStack(
+      builder: (context, state, navigationShell) {
+        return AppShell(navigationShell: navigationShell);
+      },
+      branches: [
+        StatefulShellBranch(
+          navigatorKey: _shellNavigatorKey,
+          routes: [
+            GoRoute(
+              path: AppRoutes.dashboard,
+              builder: (context, state) => Dashboard(),
+            ),
+          ],
+        ),
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: AppRoutes.appointment,
+              builder: (context, state) => AppointmentPage(),
+            ),
+          ],
+        ),
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: AppRoutes.medicalStore,
+              builder: (context, state) => MedicalStorePage(),
+            ),
+          ],
+        ),
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: AppRoutes.favourite,
+              builder: (context, state) => FavouritesPage(),
+            ),
+          ],
+        ),
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: AppRoutes.profile,
+              builder: (context, state) => ProfilePage(),
+            ),
+          ],
+        ),
+      ],
     ),
 
     GoRoute(
@@ -26,30 +80,16 @@ final GoRouter router = GoRouter(
       builder: (context, state) => LocationPage(),
     ),
 
-    // GoRoute(
-    //   path: AppRoutes.partnership,
-    //   builder: (context, state) => RequestPage(),
-    // ),
-    GoRoute(
-      path: AppRoutes.home,
-      builder: (context, state) => HomePage(),
-    ),
-    GoRoute(
-      path: AppRoutes.dashboard,
-      builder: (context, state) => Dashboard(),
-    ),
     GoRoute(
       path: AppRoutes.appointment,
       builder: (context, state) => UnifiedAppointmentPage(),
     ),
-    // GoRoute(
-    //   path: AppRoutes.submenu,
-    //   builder: (context, state) => SubmenuPage(),
-    // ),
+
     GoRoute(
       path: AppRoutes.signUp,
       builder: (context, state) => SignUpPage(),
     ),
+
     GoRoute(
       path: AppRoutes.signIn,
       builder: (context, state) {
@@ -58,11 +98,24 @@ final GoRouter router = GoRouter(
     ),
 
     GoRoute(
-      path: AppRoutes.profile,
+      path: AppRoutes.pharmaServices,
       builder: (context, state) {
-        return ProfilePage();
+        return PharmaServices();
       },
     ),
+    GoRoute(
+      path: AppRoutes.nursingServices,
+      builder: (context, state) {
+        return NursingService();
+      },
+    ),
+    GoRoute(
+      path: AppRoutes.diabeticCare,
+      builder: (context, state) {
+        return DiabeticCare();
+      },
+    ),
+
     GoRoute(
       path: AppRoutes.pharma_profile,
       builder: (context, state) {
@@ -79,7 +132,7 @@ final GoRouter router = GoRouter(
       },
     ),
   ],
-  errorPageBuilder: (context, state) {
-    return MaterialPage(child: HomePage());
-  },
+  // errorPageBuilder: (context, state) {
+  //   return MaterialPage(child: HomePage());
+  // },
 );

--- a/lib/route/app_router.dart
+++ b/lib/route/app_router.dart
@@ -1,119 +1,28 @@
 import 'package:flutter/material.dart';
-import 'package:m2health/cubit/appointment/appointment_module.dart';
-import 'package:m2health/cubit/nursing/pages/nursing_services_page.dart';
-import 'package:m2health/cubit/nursingclean/presentation/pages/pharmacist_services.dart';
-import 'package:m2health/views/appointment/unified_appointment_page.dart';
+import 'package:m2health/route/auth_routes.dart';
+import 'package:m2health/route/core_routes.dart';
+import 'package:m2health/route/dashboard_routes.dart';
 import 'package:go_router/go_router.dart';
 import 'package:m2health/cubit/locations/location_page.dart';
-import 'package:m2health/cubit/profiles/profile_page.dart';
-import 'package:m2health/cubit/signup/sign_up_page.dart';
-import 'package:m2health/cubit/signin/sign_in_page.dart';
 import 'package:m2health/cubit/pharmacist_profile/pharmacist_profile_page.dart';
 import 'package:m2health/cubit/personal/personal_page.dart';
-import 'package:m2health/main.dart';
-import 'package:m2health/views/dashboard.dart';
-import 'package:m2health/views/diabetic_care.dart';
-import 'package:m2health/views/favourites.dart';
-import 'package:m2health/views/medical_store.dart';
-import 'package:path/path.dart';
+import 'package:m2health/route/profile_detail_routes.dart';
 import 'app_routes.dart';
 
 final _rootNavigatorKey = GlobalKey<NavigatorState>();
-final _shellNavigatorKey = GlobalKey<NavigatorState>();
 
 final GoRouter router = GoRouter(
   initialLocation: AppRoutes.dashboard,
   navigatorKey: _rootNavigatorKey,
   routes: [
-    // For routes with NavigationBar
-    StatefulShellRoute.indexedStack(
-      builder: (context, state, navigationShell) {
-        return AppShell(navigationShell: navigationShell);
-      },
-      branches: [
-        StatefulShellBranch(
-          navigatorKey: _shellNavigatorKey,
-          routes: [
-            GoRoute(
-              path: AppRoutes.dashboard,
-              builder: (context, state) => Dashboard(),
-            ),
-          ],
-        ),
-        StatefulShellBranch(
-          routes: [
-            GoRoute(
-              path: AppRoutes.appointment,
-              builder: (context, state) => AppointmentPage(),
-            ),
-          ],
-        ),
-        StatefulShellBranch(
-          routes: [
-            GoRoute(
-              path: AppRoutes.medicalStore,
-              builder: (context, state) => MedicalStorePage(),
-            ),
-          ],
-        ),
-        StatefulShellBranch(
-          routes: [
-            GoRoute(
-              path: AppRoutes.favourite,
-              builder: (context, state) => FavouritesPage(),
-            ),
-          ],
-        ),
-        StatefulShellBranch(
-          routes: [
-            GoRoute(
-              path: AppRoutes.profile,
-              builder: (context, state) => ProfilePage(),
-            ),
-          ],
-        ),
-      ],
-    ),
+    ...CoreRoutes.routes, // NavBar Routes
+    ...AuthRoutes.routes,
+    ...DashboardRoutes.routes,
+    ...ProfileDetailRoutes.routes,
 
     GoRoute(
       path: '/locations',
       builder: (context, state) => LocationPage(),
-    ),
-
-    GoRoute(
-      path: AppRoutes.appointment,
-      builder: (context, state) => UnifiedAppointmentPage(),
-    ),
-
-    GoRoute(
-      path: AppRoutes.signUp,
-      builder: (context, state) => SignUpPage(),
-    ),
-
-    GoRoute(
-      path: AppRoutes.signIn,
-      builder: (context, state) {
-        return SignInPage();
-      },
-    ),
-
-    GoRoute(
-      path: AppRoutes.pharmaServices,
-      builder: (context, state) {
-        return PharmaServices();
-      },
-    ),
-    GoRoute(
-      path: AppRoutes.nursingServices,
-      builder: (context, state) {
-        return NursingService();
-      },
-    ),
-    GoRoute(
-      path: AppRoutes.diabeticCare,
-      builder: (context, state) {
-        return DiabeticCare();
-      },
     ),
 
     GoRoute(
@@ -125,7 +34,7 @@ final GoRouter router = GoRouter(
     GoRoute(
       path: AppRoutes.personal,
       builder: (context, state) {
-        return PersonalPage(
+        return const PersonalPage(
           title: 'Personal Page',
           serviceType: 'Default Service',
         );

--- a/lib/route/app_routes.dart
+++ b/lib/route/app_routes.dart
@@ -1,17 +1,29 @@
 class AppRoutes {
+  // Core
   static const String home = '/';
   static const String dashboard = home;
   static const String appointment = '/appointment';
   static const String medicalStore = '/medical-store';
   static const String favourite = '/favourite';
   static const String profile = '/profile';
+
+  // Auth
   static const String signIn = '/sign-in';
   static const String signUp = '/sign-up';
 
-  // Dasboard Menus
+  // Dasboard Services
   static const String pharmaServices = '/pharma-services';
   static const String nursingServices = '/nursing-services';
   static const String diabeticCare = '/diabetic-care';
+  static const String homeHealthScreening = '/home-health-screening';
+  static const String remotePatientMonitoring = '/remote-patient-monitoring';
+  static const String secondOpinionMedical = '/second-opinion-medical';
+  static const String precisionNutrition = '/precision-nutrition';
+
+  // Profile Detail
+  static const String medicalRecord = '/medical-record';
+  static const String pharmagenomics = '/pharmagenomics';
+  static const String editProfile = '/edit-profile';
 
   static const String partnership = '/request-partnership';
   static const String partnership_list = '/partnership-list';

--- a/lib/route/app_routes.dart
+++ b/lib/route/app_routes.dart
@@ -1,18 +1,26 @@
 class AppRoutes {
   static const String home = '/';
-  static const String submenu = '/submenu';
-  static const String dashboard = '/dashboard';
+  static const String dashboard = home;
+  static const String appointment = '/appointment';
+  static const String medicalStore = '/medical-store';
+  static const String favourite = '/favourite';
+  static const String profile = '/profile';
   static const String signIn = '/sign-in';
   static const String signUp = '/sign-up';
+
+  // Dasboard Menus
+  static const String pharmaServices = '/pharma-services';
+  static const String nursingServices = '/nursing-services';
+  static const String diabeticCare = '/diabetic-care';
+
   static const String partnership = '/request-partnership';
   static const String partnership_list = '/partnership-list';
   static const String service_request = '/service-request';
-  static const String profile = '/profile';
   static const String chat = '/chat';
   static const String pharma_profile = '/pharma-profile';
   static const String personal = '/personal';
   static const String nursing = '/nursing';
-  static const String appointment = '/appointment';
+  static const String submenu = '/submenu';
 
   // static const String home = '/';
   // static const String submenu = 'submenu';

--- a/lib/route/auth_routes.dart
+++ b/lib/route/auth_routes.dart
@@ -1,0 +1,20 @@
+import 'package:go_router/go_router.dart';
+import 'package:m2health/cubit/signin/sign_in_page.dart';
+import 'package:m2health/cubit/signup/sign_up_page.dart';
+import 'package:m2health/route/app_routes.dart';
+
+class AuthRoutes {
+  static List<GoRoute> routes = [
+    GoRoute(
+      path: AppRoutes.signUp,
+      builder: (context, state) => SignUpPage(),
+    ),
+
+    GoRoute(
+      path: AppRoutes.signIn,
+      builder: (context, state) {
+        return SignInPage();
+      },
+    ),
+  ];
+}

--- a/lib/route/core_routes.dart
+++ b/lib/route/core_routes.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/cupertino.dart';
+import 'package:go_router/go_router.dart';
+import 'package:m2health/cubit/appointment/appointment_module.dart';
+import 'package:m2health/main.dart';
+import 'package:m2health/route/app_routes.dart';
+import 'package:m2health/views/dashboard.dart';
+import 'package:m2health/views/favourites.dart';
+import 'package:m2health/views/medical_store.dart';
+import 'package:m2health/cubit/profiles/profile_page.dart';
+
+final _shellNavigatorKey = GlobalKey<NavigatorState>();
+
+class CoreRoutes {
+  static List<RouteBase> routes = [
+    StatefulShellRoute.indexedStack(
+      builder: (context, state, navigationShell) {
+        return AppShell(navigationShell: navigationShell);
+      },
+      branches: [
+        StatefulShellBranch(
+          navigatorKey: _shellNavigatorKey,
+          routes: [
+            GoRoute(
+              path: AppRoutes.dashboard,
+              builder: (context, state) => Dashboard(),
+            ),
+          ],
+        ),
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: AppRoutes.appointment,
+              builder: (context, state) => AppointmentPage(),
+            ),
+          ],
+        ),
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: AppRoutes.medicalStore,
+              builder: (context, state) => MedicalStorePage(),
+            ),
+          ],
+        ),
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: AppRoutes.favourite,
+              builder: (context, state) => FavouritesPage(),
+            ),
+          ],
+        ),
+        StatefulShellBranch(
+          routes: [
+            GoRoute(
+              path: AppRoutes.profile,
+              builder: (context, state) => ProfilePage(),
+            ),
+          ],
+        ),
+      ],
+    ),
+  ];
+}

--- a/lib/route/dashboard_routes.dart
+++ b/lib/route/dashboard_routes.dart
@@ -1,0 +1,63 @@
+import 'package:go_router/go_router.dart';
+import 'package:m2health/views/dashboard.dart';
+import '../cubit/nursing/pages/nursing_services.dart';
+import '../cubit/nursing/pages/pharmacist_services.dart';
+import '../cubit/precision/precision_page.dart';
+import '../views/diabetic_care.dart';
+import '../views/home_health_screening.dart';
+import '../views/remote_patient_monitoring.dart';
+import '../views/second_opinion.dart';
+import 'app_routes.dart';
+
+class DashboardRoutes {
+  static List<GoRoute> routes = [
+    GoRoute(
+      path: AppRoutes.pharmaServices,
+      builder: (context, state) {
+        return PharmaServices();
+      },
+    ),
+    GoRoute(
+      path: AppRoutes.nursingServices,
+      builder: (context, state) {
+        return NursingService();
+      },
+    ),
+    GoRoute(
+      path: AppRoutes.diabeticCare,
+      builder: (context, state) {
+        return DiabeticCare();
+      },
+    ),
+    GoRoute(
+      path: AppRoutes.homeHealthScreening,
+      builder: (context, state) {
+        return HomeHealth();
+      },
+    ),
+    GoRoute(
+      path: AppRoutes.homeHealthScreening,
+      builder: (context, state) {
+        return HomeHealth();
+      },
+    ),
+    GoRoute(
+      path: AppRoutes.remotePatientMonitoring,
+      builder: (context, state) {
+        return RemotePatientMonitoring();
+      },
+    ),
+    GoRoute(
+      path: AppRoutes.secondOpinionMedical,
+      builder: (context, state) {
+        return OpinionMedical();
+      },
+    ),
+    GoRoute(
+      path: AppRoutes.precisionNutrition,
+      builder: (context, state) {
+        return PrecisionNutritionPage();
+      },
+    ),
+  ];
+}

--- a/lib/route/profile_detail_routes.dart
+++ b/lib/route/profile_detail_routes.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:m2health/cubit/pharmacogenomics/presentation/pharmagenomical_pages.dart';
+import 'package:m2health/cubit/profiles/profile_details/edit_profile.dart';
+import 'package:m2health/cubit/profiles/profile_details/medical_record/medical_record.dart';
+import 'package:m2health/route/app_routes.dart';
+
+class ProfileDetailRoutes {
+  static List<GoRoute> routes = [
+    GoRoute(
+      path: AppRoutes.medicalRecord,
+      builder: (context, state) {
+        return MedicalRecordsPage();
+      },
+    ),
+    GoRoute(
+      path: AppRoutes.pharmagenomics,
+      builder: (context, state) {
+        return PharmagenomicsProfilePage();
+      },
+    ),
+    GoRoute(
+      path: AppRoutes.editProfile,
+      builder: (context, state) {
+        final args = state.extra as EditProfilePageArgs;
+        return BlocProvider.value(
+          value: args.profileCubit,
+          child: EditProfilePage(profile: args.profile),
+        );
+      }
+    ),
+  ];
+}

--- a/lib/views/appointment/appointment_detail_page.dart
+++ b/lib/views/appointment/appointment_detail_page.dart
@@ -1,9 +1,11 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
 import 'package:m2health/const.dart';
 import 'package:m2health/cubit/appointment/appointment_cubit.dart';
 import 'package:m2health/cubit/appointment/appointment_detail.dart';
 import 'package:m2health/main.dart';
+import 'package:m2health/route/app_routes.dart';
 import 'package:m2health/views/appointment/appointment_detail_page.dart';
 import 'package:m2health/cubit/appointment/appointment_manager.dart';
 import 'package:m2health/models/appointment.dart';
@@ -147,13 +149,7 @@ class _AppointmentPageState extends State<AppointmentPage>
         padding: const EdgeInsets.all(16.0),
         child: ElevatedButton(
           onPressed: () {
-            Navigator.pop(context);
-            Navigator.pushReplacement(
-              context,
-              MaterialPageRoute(
-                builder: (context) => HomePage(),
-              ),
-            );
+            context.go(AppRoutes.home);
           },
           style: ElevatedButton.styleFrom(
             backgroundColor: Const.tosca,

--- a/lib/views/dashboard.dart
+++ b/lib/views/dashboard.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:m2health/cubit/nursing/pages/nursing_services.dart';
 import 'package:m2health/cubit/profiles/profile_page.dart';
+import 'package:m2health/route/app_routes.dart';
 import 'package:m2health/views/diabetic_care.dart';
 import 'package:m2health/views/home_health_screening.dart';
 import 'package:m2health/views/pharmacist_services.dart';
@@ -181,12 +183,7 @@ class _DashboardState extends State<Dashboard> {
                           const Spacer(),
                           GestureDetector(
                             onTap: () {
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                  builder: (context) => ProfilePage(),
-                                ),
-                              );
+                              context.go(AppRoutes.profile);
                             },
                             child: Container(
                               width: 56,
@@ -310,11 +307,7 @@ class _DashboardState extends State<Dashboard> {
                       RectangularIconWithTitle(
                         onTap: () {
                           // navbarVisibility(true);
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                                builder: (context) => PharmaServices()),
-                          );
+                          context.push(AppRoutes.pharmaServices);
                         },
                         iconPath:
                             'assets/icons/ic_pharma_service.png', // Replace with your actual image path
@@ -327,11 +320,7 @@ class _DashboardState extends State<Dashboard> {
                       RectangularIconWithTitle(
                         onTap: () {
                           // navbarVisibility(true);
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                                builder: (context) => NursingService()),
-                          );
+                          context.push(AppRoutes.nursingServices);
                         },
                         iconPath:
                             'assets/icons/ic_nurse.png', // Replace with your actual image path
@@ -344,11 +333,7 @@ class _DashboardState extends State<Dashboard> {
                       RectangularIconWithTitle(
                         onTap: () {
                           // navbarVisibility(true);
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                                builder: (context) => DiabeticCare()),
-                          );
+                          context.go(AppRoutes.diabeticCare);
                         },
                         iconPath:
                             'assets/icons/ic_diabetic.png', // Replace with your actual image path

--- a/lib/views/dashboard.dart
+++ b/lib/views/dashboard.dart
@@ -422,11 +422,7 @@ class _DashboardState extends State<Dashboard> {
                         children: [
                           TextButton(
                             onPressed: () {
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (context) => ProfilePage()),
-                              );
+                              context.go(AppRoutes.profile);
                             },
                             child: const Text('View all',
                                 style: TextStyle(

--- a/lib/views/dashboard.dart
+++ b/lib/views/dashboard.dart
@@ -333,7 +333,7 @@ class _DashboardState extends State<Dashboard> {
                       RectangularIconWithTitle(
                         onTap: () {
                           // navbarVisibility(true);
-                          context.go(AppRoutes.diabeticCare);
+                          context.push(AppRoutes.diabeticCare);
                         },
                         iconPath:
                             'assets/icons/ic_diabetic.png', // Replace with your actual image path
@@ -351,12 +351,7 @@ class _DashboardState extends State<Dashboard> {
                     children: [
                       RectangularIconWithTitle(
                         onTap: () {
-                          // navbarVisibility(true);
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                                builder: (context) => HomeHealth()),
-                          );
+                          context.push(AppRoutes.homeHealthScreening);
                         },
                         iconPath: 'assets/icons/ic_report.png',
                         title: AppLocalizations.of(context)!
@@ -366,22 +361,8 @@ class _DashboardState extends State<Dashboard> {
                         titleColor: Colors.black,
                       ),
                       RectangularIconWithTitle(
-                        // onTap: () {
-                        //   showDialog(
-                        //     context: context,
-                        //     builder: (BuildContext context) {
-                        //       return ComingSoonDialog();
-                        //     },
-                        //   );
-                        // },
                         onTap: () {
-                          // navbarVisibility(true);
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                                builder: (context) =>
-                                    RemotePatientMonitoring()),
-                          );
+                          context.push(AppRoutes.remotePatientMonitoring);
                         },
                         iconPath: 'assets/icons/ic_drug.png',
                         title: AppLocalizations.of(context)!
@@ -392,12 +373,7 @@ class _DashboardState extends State<Dashboard> {
                       ),
                       RectangularIconWithTitle(
                         onTap: () {
-                          // navbarVisibility(true);
-                          Navigator.push(
-                            context,
-                            MaterialPageRoute(
-                                builder: (context) => OpinionMedical()),
-                          );
+                          context.push(AppRoutes.secondOpinionMedical);
                         },
                         iconPath: 'assets/icons/ic_lung.png',
                         title: AppLocalizations.of(context)!
@@ -476,12 +452,7 @@ class _DashboardState extends State<Dashboard> {
                           onTap: () {
                             if (services[index]['name'] ==
                                 'Precision\nNutrition') {
-                              Navigator.push(
-                                context,
-                                MaterialPageRoute(
-                                    builder: (context) =>
-                                        PrecisionNutritionPage()),
-                              );
+                              context.push(AppRoutes.precisionNutrition);
                             } else {
                               showDialog(
                                 context: context,

--- a/lib/views/details/detail_appointment.dart
+++ b/lib/views/details/detail_appointment.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/material.dart';
 import 'package:intl/intl.dart';
+import 'package:go_router/go_router.dart';
 import 'package:m2health/const.dart';
 import 'package:m2health/main.dart';
+import 'package:m2health/route/app_routes.dart';
 import 'package:m2health/utils.dart';
 import 'package:dio/dio.dart';
 import 'package:m2health/views/payment.dart';
@@ -292,15 +294,8 @@ class _DetailAppointmentPageState extends State<DetailAppointmentPage> {
   }
 
   void _navigateToAppointmentPage() {
-    Navigator.pop(context);
-    Navigator.pushReplacement(
-      context,
-      MaterialPageRoute(
-        builder: (context) => HomePage(),
-      ),
-    ).then((_) {
-      MyApp.showBottomAppBar(context);
-    });
+    context.go(AppRoutes.home);
+    MyApp.showBottomAppBar(context);
   }
 
   @override

--- a/lib/views/payment.dart
+++ b/lib/views/payment.dart
@@ -1,6 +1,8 @@
 import 'package:flutter/material.dart';
+import 'package:go_router/go_router.dart';
 import 'package:m2health/const.dart';
 import 'package:m2health/main.dart';
+import 'package:m2health/route/app_routes.dart';
 import 'package:m2health/views/appointment/appointment_detail_page.dart';
 
 class PaymentPage extends StatefulWidget {
@@ -312,13 +314,7 @@ class PaymentSuccessDialog extends StatelessWidget {
             height: 50,
             child: ElevatedButton(
               onPressed: () {
-                Navigator.pop(context);
-                Navigator.pushReplacement(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => HomePage(),
-                  ),
-                );
+                context.go(AppRoutes.home);
               },
               style: ElevatedButton.styleFrom(
                 backgroundColor: Const.tosca,

--- a/lib/views/radiologist_payment.dart
+++ b/lib/views/radiologist_payment.dart
@@ -3,6 +3,7 @@ import 'package:m2health/const.dart';
 import 'package:m2health/main.dart';
 import 'package:m2health/cubit/appointment/appointment_page.dart';
 import 'package:go_router/go_router.dart';
+import 'package:m2health/route/app_routes.dart';
 import 'package:m2health/widgets/bottombar.dart';
 
 class RadiologistPaymentPage extends StatefulWidget {
@@ -325,13 +326,7 @@ class RadiologistPaymentSuccessDialog extends StatelessWidget {
             height: 50,
             child: ElevatedButton(
               onPressed: () {
-                Navigator.pop(context);
-                Navigator.pushReplacement(
-                  context,
-                  MaterialPageRoute(
-                    builder: (context) => HomePage(),
-                  ),
-                );
+                context.go(AppRoutes.home);
               },
               style: ElevatedButton.styleFrom(
                 backgroundColor: Const.tosca,
@@ -567,15 +562,8 @@ class RadiologistFeedbackDetails extends StatelessWidget {
                 width: 300,
                 child: ElevatedButton(
                   onPressed: () {
-                    Navigator.pop(context);
-                    Navigator.pushReplacement(
-                      context,
-                      MaterialPageRoute(
-                        builder: (context) => HomePage(),
-                      ),
-                    ).then((_) {
-                      MyApp.showBottomAppBar(context);
-                    });
+                    context.go(AppRoutes.home);
+                    MyApp.showBottomAppBar(context);
                   },
                   child: const Text(
                     'View Appointments',

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -93,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: "04a925763edad70e8443c99234dc3328f442e811f1d8fd1a72f1c8ad0f69a605"
+      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.4.0"
   chewie:
     dependency: transitive
     description:
@@ -109,18 +109,18 @@ packages:
     dependency: transitive
     description:
       name: clock
-      sha256: cb6d7f03e1de671e34607e909a7213e31d7752be4fb66a86d29fe1eb14bfb5cf
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.1"
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: "2f5709ae4d3d59dd8f7cd309b4e023046b57d8a6c82130785d2b0e5868084e76"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.19.1"
   convert:
     dependency: transitive
     description:
@@ -237,10 +237,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "511392330127add0b769b75a987850d136345d9227c6b94c96a04cf4a391bf78"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.1"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -309,10 +309,10 @@ packages:
     dependency: "direct main"
     description:
       name: fleather
-      sha256: "622231d66508fd2f481824134e0e4e539168f20a5ec513c8c6246f5b8c8240da"
+      sha256: ef2d47562db57414c320b8b093834dd8e2c0ffb033d82eb92281e0fb848ea9ef
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.23.0"
   flutter:
     dependency: "direct main"
     description: flutter
@@ -630,13 +630,13 @@ packages:
     source: hosted
     version: "0.2.1+1"
   intl:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   json_annotation:
     dependency: transitive
     description:
@@ -673,26 +673,26 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: "8dcda04c3fc16c14f48a7bb586d4be1f0d1572731b6d81d51772ef47c02081e0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.7"
+    version: "11.0.1"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: "1dbc140bb5a23c75ea9c4811222756104fbcd1a27173f0c34ca01e16bea473c1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.10"
   leak_tracker_testing:
     dependency: transitive
     description:
       name: leak_tracker_testing
-      sha256: "6ba465d5d76e67ddf503e1161d1f4a6bc42306f9d66ca1e8f079a47290fb06d3"
+      sha256: "8d5a2d49f4a66b49744b23b018848400d23e54caf9463f4eb20df3eb8acb2eb1"
       url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   lints:
     dependency: transitive
     description:
@@ -721,10 +721,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: d2323aa2060500f906aa31a895b4030b6da3ebdcc5619d14ce1aada65cd161cb
+      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.16+1"
+    version: "0.12.17"
   material_color_utilities:
     dependency: transitive
     description:
@@ -737,10 +737,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: bdb68674043280c3428e9ec998512fb681678676b3c54e773629ffe74419f8c7
+      sha256: e3641ec5d63ebf0d9b41bd43201a66e3fc79a65db5f61fc181f04cd27aab950c
       url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.16.0"
   mime:
     dependency: transitive
     description:
@@ -801,10 +801,10 @@ packages:
     dependency: transitive
     description:
       name: parchment
-      sha256: a7b4ae5bc7fcfe29909840246d824651315b09cae2176708f86c6ce7f8236019
+      sha256: "5b957b973f83ae4207edbcb52665d1fdc18a55a76829bc7d50ecdf12838dfeed"
       url: "https://pub.dev"
     source: hosted
-    version: "1.19.0"
+    version: "1.22.0"
   parchment_delta:
     dependency: transitive
     description:
@@ -817,10 +817,10 @@ packages:
     dependency: "direct main"
     description:
       name: path
-      sha256: "087ce49c3f0dc39180befefc60fdb4acd8f8620e5682fe2476afd0b3688bb4af"
+      sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"
       url: "https://pub.dev"
     source: hosted
-    version: "1.9.0"
+    version: "1.9.1"
   path_parsing:
     dependency: transitive
     description:
@@ -1086,18 +1086,18 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "8b27215b45d22309b5cddda1aa2b19bdfec9df0e765f2de506401c071d38d1b1"
       url: "https://pub.dev"
     source: hosted
-    version: "1.12.0"
+    version: "1.12.1"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      sha256: ba2aa5d8cc609d96bbb2899c28934f9e1af5cddbd60a827822ea467161eb54e7
+      sha256: "969e04c80b8bcdf826f8f16579c7b14d780458bd97f56d107d3950fdbeef059d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.2"
+    version: "2.1.4"
   string_scanner:
     dependency: transitive
     description:
@@ -1182,10 +1182,10 @@ packages:
     dependency: "direct main"
     description:
       name: table_calendar
-      sha256: b2896b7c86adf3a4d9c911d860120fe3dbe03c85db43b22fd61f14ee78cdbb63
+      sha256: "0c0c6219878b363a2d5f40c7afb159d845f253d061dc3c822aa0d5fe0f721982"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -1198,18 +1198,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.3"
-  time_slot:
-    dependency: "direct main"
-    description:
-      name: time_slot
-      sha256: a8d59c209d556e76b55f9eb8a9a701019857efc18c1a92279f228711173de814
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.2"
+    version: "0.7.6"
   typed_data:
     dependency: transitive
     description:
@@ -1318,10 +1310,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   video_player:
     dependency: transitive
     description:
@@ -1459,5 +1451,5 @@ packages:
     source: hosted
     version: "6.5.0"
 sdks:
-  dart: ">=3.5.4 <4.0.0"
-  flutter: ">=3.24.0"
+  dart: ">=3.8.0-0 <4.0.0"
+  flutter: ">=3.32.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -41,7 +41,7 @@ dependencies:
   http: ^1.1.0
   flutter_cache_manager: ^3.3.1
   flutter_image_compress: ^2.1.0
-  intl: 0.19.0
+  # intl: 0.19.0
   url_launcher: ^6.2.2
   flutter_pdfview: ^1.2.7
   path_provider: ^2.1.1
@@ -66,7 +66,7 @@ dependencies:
   flutter_floating_bottom_bar: ^1.2.1+1
   gradient_borders: ^1.0.1
   table_calendar: ^3.0.0
-  time_slot: ^1.0.0
+  # time_slot: ^1.0.0
   rename: ^3.0.2
   file_picker: ^8.1.7
   syncfusion_flutter_pdfviewer: ^28.2.9


### PR DESCRIPTION
This PR resolves a navigation issue where navigating between main tabs programmatically (e.g., from the Dashboard's avatar to the Profile page) would cause the bottom navigation bar to disappear. 

The entire navigation system has been refactored to consistently use `go_router`'s APIs.

Beside that, it also include some dependencies fix for android apk building.

#### **Key Changes:**
* Replaced all legacy `Navigator.push`/`pop` calls with their `go_router` equivalents (`context.push`, `goBranch`).
* Ensures that sub-pages (like `EditProfilePage`) are pushed on top of the main shell, correctly hiding the navbar for a consistent UX.
* Unified all primary navigation under `StatefulShellRoute` to prevent inconsistent UI states and simplify the navigation logic.